### PR TITLE
Port of the function Copy table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ version := "0.0.1"
 
 scalaVersion := "2.12.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.1.1" % "provided"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.3.1" % "provided"
 
-libraryDependencies += "io.delta" %% "delta-core" % "1.0.0" % "provided"
+libraryDependencies += "io.delta" %% "delta-core" % "2.1.0" % "provided"
 libraryDependencies += "com.github.mrpowers" %% "spark-daria" % "0.38.2"
 libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.0.0" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
+++ b/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
@@ -2,6 +2,8 @@ package mrpowers.jodie
 
 import org.apache.spark.sql.SparkSession
 import io.delta.tables._
+import org.apache.spark.sql.expressions.Window.partitionBy
+import org.apache.spark.sql.functions.{col, count}
 
 object DeltaHelpers {
 
@@ -15,6 +17,43 @@ object DeltaHelpers {
       .select("version")
       .head()(0)
       .asInstanceOf[Long]
+  }
+
+  /**
+   * This function remove all duplicate records from a delta table.
+   * Duplicate records means all rows that have more than one occurrence
+   * of the value of the columns provided in the input parameter duplicationColumns.
+   *
+   * @param deltaTable: delta table object
+   * @param duplicateColumns: collection of columns names that represent the duplication key.
+   */
+  def removeDuplicateRecords(deltaTable: DeltaTable, duplicateColumns: Seq[String] ): Unit ={
+    val df = deltaTable.toDF
+
+    //1 Validate duplicateColumns is not empty
+    if(duplicateColumns.isEmpty)
+      throw new NoSuchElementException("the input parameter duplicateColumns could not be empty")
+
+    //2 Validate duplicateColumns exists in the delta table.
+    val tableColumns = df.columns.toSeq
+    if(duplicateColumns.diff(tableColumns).nonEmpty){
+      throw JodieValidationError(s"there are columns in duplicateColumns:$duplicateColumns that do not exists in the deltaTable: $tableColumns")
+    }
+
+    //3 execute query statement with windows function that will help you identify duplicated records.
+    val duplicatedRecords = df
+      .withColumn("quantity",count("*").over(partitionBy(duplicateColumns.map(c => col(c)):_*)))
+      .filter("quantity>1")
+      .drop("quantity")
+      .distinct()
+
+    //4 execute delete statement to remove duplicate records from the delta table.
+    val deleteCondition = duplicateColumns.map(dc=> s"old.$dc = new.$dc").mkString(" AND ")
+    deltaTable.alias("old")
+      .merge(duplicatedRecords.alias("new"),deleteCondition)
+      .whenMatched()
+      .delete()
+      .execute()
   }
 
 }

--- a/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
+++ b/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
@@ -3,7 +3,7 @@ package mrpowers.jodie
 import org.apache.spark.sql.SparkSession
 import io.delta.tables._
 import org.apache.spark.sql.expressions.Window.partitionBy
-import org.apache.spark.sql.functions.{col, count}
+import org.apache.spark.sql.functions.{col, count, row_number}
 
 object DeltaHelpers {
 
@@ -32,13 +32,10 @@ object DeltaHelpers {
 
     //1 Validate duplicateColumns is not empty
     if(duplicateColumns.isEmpty)
-      throw new NoSuchElementException("the input parameter duplicateColumns could not be empty")
+      throw new NoSuchElementException("the input parameter duplicateColumns must not be empty")
 
     //2 Validate duplicateColumns exists in the delta table.
-    val tableColumns = df.columns.toSeq
-    if(duplicateColumns.diff(tableColumns).nonEmpty){
-      throw JodieValidationError(s"there are columns in duplicateColumns:$duplicateColumns that do not exists in the deltaTable: $tableColumns")
-    }
+    JodieValidator.validateColumnsExistsInDataFrame(duplicateColumns,df)
 
     //3 execute query statement with windows function that will help you identify duplicated records.
     val duplicatedRecords = df
@@ -51,6 +48,51 @@ object DeltaHelpers {
     val deleteCondition = duplicateColumns.map(dc=> s"old.$dc = new.$dc").mkString(" AND ")
     deltaTable.alias("old")
       .merge(duplicatedRecords.alias("new"),deleteCondition)
+      .whenMatched()
+      .delete()
+      .execute()
+  }
+
+  /**
+   * This function remove duplicate records from a delta table keeping
+   * only one occurrence of the deleted record. If not duplicate columns are
+   * provided them the primary key is used as partition key to identify duplication.
+   * @param deltaTable: delta table object
+   * @param duplicateColumns: collection of columns names that represent the duplication key.
+   * @param primaryKey: name of the primary key column associated to the delta table.
+   */
+  def removeDuplicateRecords(deltaTable: DeltaTable, primaryKey: String,duplicateColumns: Seq[String] = Nil): Unit = {
+    val df = deltaTable.toDF
+    // 1 Validate primaryKey is not empty
+    if(primaryKey.isEmpty){
+      throw new NoSuchElementException("the input parameter primaryKey must not be empty")
+    }
+
+    // 2 Validate if duplicateColumns is not empty that all its columns are in the delta table
+    JodieValidator.validateColumnsExistsInDataFrame(duplicateColumns,df)
+
+    // 3 execute query using window function to find duplicate records. Create a match expression to evaluate
+    // the case when duplicateColumns is empty and when it is not empty
+    val duplicateRecords = duplicateColumns match {
+      case Nil =>
+        df.withColumn("row_number",
+          row_number().over(partitionBy(primaryKey).orderBy(primaryKey)))
+          .filter("row_number>1")
+          .drop("row_number")
+          .distinct()
+
+      case columns =>
+        df.withColumn("row_number",
+          row_number().over(partitionBy(columns.map(c=>col(c)):_*).orderBy(primaryKey)))
+        .filter("row_number>1")
+        .drop("row_number")
+        .distinct()
+    }
+
+    // 4 execute delete statement  in the delta table
+    val deleteCondition = (Seq(primaryKey) ++ duplicateColumns).map(c => s"old.$c = new.$c").mkString(" AND ")
+    deltaTable.alias("old")
+      .merge(duplicateRecords.as("new"),deleteCondition)
       .whenMatched()
       .delete()
       .execute()

--- a/src/main/scala/mrpowers/jodie/JodieValidator.scala
+++ b/src/main/scala/mrpowers/jodie/JodieValidator.scala
@@ -1,0 +1,14 @@
+package mrpowers.jodie
+
+import org.apache.spark.sql.DataFrame
+
+case class JodieValidationError(smth: String) extends Exception(smth)
+object JodieValidator {
+  def validateColumnsExistsInDataFrame(columns:Seq[String],df:DataFrame):Unit ={
+    val dataFrameColumns = df.columns.toSeq
+    val noExistingColumns = columns.diff(dataFrameColumns)
+    if (noExistingColumns.nonEmpty) {
+      throw JodieValidationError(s"these columns: $noExistingColumns do not exists in the dataframe: $dataFrameColumns")
+    }
+  }
+}

--- a/src/main/scala/mrpowers/jodie/Type2Scd.scala
+++ b/src/main/scala/mrpowers/jodie/Type2Scd.scala
@@ -4,9 +4,6 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import io.delta.tables._
 
 
-case class JodieValidationError(smth: String) extends Exception(smth)
-
-
 object Type2Scd {
 
   def upsert(

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{BeforeAndAfterEach, FunSpec}
 
 class DeltaHelperSpec extends FunSpec with SparkSessionTestWrapper with DataFrameComparer with BeforeAndAfterEach {
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     val tmpDir = os.pwd / "tmp"
     os.remove.all(tmpDir)
   }
@@ -73,15 +73,15 @@ class DeltaHelperSpec extends FunSpec with SparkSessionTestWrapper with DataFram
       df.write.format("delta").mode("overwrite").save(path)
       val deltaTable = DeltaTable.forPath(path)
       val duplicateColumns = Seq()
-      val e = intercept[NoSuchElementException]{
+      val exceptionMessage = intercept[NoSuchElementException]{
         DeltaHelpers.removeDuplicateRecords(deltaTable, duplicateColumns)
       }.getMessage
 
-      assert(e.contains("the input parameter duplicateColumns could not be empty"))
+      assert(exceptionMessage.contains("the input parameter duplicateColumns must not be empty"))
     }
 
     it("should fail to remove duplicate when duplicateColumns does not exist in table") {
-      val path = (os.pwd / "tmp" / "delta-duplicate-empty-list").toString()
+      val path = (os.pwd / "tmp" / "delta-duplicate-not-in-table").toString()
       val df = Seq(
         (1, "Benito", "Jackson"),
         (2, "Maria", "Willis"),
@@ -91,11 +91,139 @@ class DeltaHelperSpec extends FunSpec with SparkSessionTestWrapper with DataFram
       df.write.format("delta").mode("overwrite").save(path)
       val deltaTable = DeltaTable.forPath(path)
       val duplicateColumns = Seq("firstname","name")
-      val e = intercept[JodieValidationError] {
+      val exceptionMessage = intercept[JodieValidationError] {
         DeltaHelpers.removeDuplicateRecords(deltaTable, duplicateColumns)
       }.getMessage
 
-      assert(e.contains(s"there are columns in duplicateColumns:$duplicateColumns that do not exists in the deltaTable: ${deltaTable.toDF.columns.toSeq}"))
+      val tableColumns = deltaTable.toDF.columns.toSeq
+      val diff = duplicateColumns.diff(tableColumns)
+      assert(exceptionMessage.contains(s"these columns: $diff do not exists in the dataframe: $tableColumns"))
+    }
+  }
+
+  describe("remove duplicate records from delta table using primary key") {
+    it("should remove duplicates given a primary key and duplicate columns") {
+      val path = (os.pwd / "tmp" / "delta-duplicate-pk").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq("lastname")
+      val primaryKey = "id"
+      DeltaHelpers.removeDuplicateRecords(deltaTable,primaryKey,duplicateColumns)
+      val resultTable = spark.read.format("delta").load(path)
+      val expectedTable = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (7, "Maria", "Pitt"),
+      ).toDF("id", "firstname", "lastname")
+      assertSmallDataFrameEquality(resultTable,expectedTable,orderedComparison = false,ignoreNullable = true)
+    }
+
+    it("should remove duplicates when not duplicate columns is provided") {
+      val path = (os.pwd / "tmp" / "delta-pk-not-duplicate-columns").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      val primaryKey = "id"
+      DeltaHelpers.removeDuplicateRecords(deltaTable, primaryKey)
+      val resultTable = spark.read.format("delta").load(path)
+      val expectedTable = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id", "firstname", "lastname")
+      assertSmallDataFrameEquality(resultTable, expectedTable, orderedComparison = false, ignoreNullable = true)
+    }
+
+    it("should execute successful when delta table is empty") {
+      val path = (os.pwd / "tmp" / "delta-duplicate-empty-table").toString()
+      val df = spark.createDF(List(), List(
+        ("id", IntegerType, true),
+        ("firstname", StringType, true),
+        ("lastname", StringType, true)),
+      )
+      df.write.format("delta").mode("overwrite").save(path)
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq("firstname", "lastname")
+      val primaryKey = "id"
+      DeltaHelpers.removeDuplicateRecords(deltaTable, primaryKey, duplicateColumns)
+      val resultTable = spark.read.format("delta").load(path)
+      val expectedTable = spark.createDF(List(), List(
+        ("id", IntegerType, true),
+        ("firstname", StringType, true),
+        ("lastname", StringType, true)),
+      )
+      assertSmallDataFrameEquality(resultTable, expectedTable, orderedComparison = false, ignoreNullable = true)
+    }
+
+    it("should fail to remove duplicate when not primary key is provided") {
+      val path = (os.pwd / "tmp" / "delta-duplicate-no-pk").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      val primaryKey = ""
+      val exceptionMessage = intercept[NoSuchElementException]{
+        DeltaHelpers.removeDuplicateRecords(deltaTable, primaryKey)
+      }.getMessage
+
+      assert(exceptionMessage.contains("the input parameter primaryKey must not be empty"))
+    }
+
+    it("should fail to remove duplicate when duplicateColumns does not exist in table") {
+      val path = (os.pwd / "tmp" / "delta-duplicate-cols-no-exists").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      val primaryKey = "id"
+      val duplicateColumns = Seq("name","lastname")
+      val exceptionMessage = intercept[JodieValidationError] {
+        DeltaHelpers.removeDuplicateRecords(deltaTable, primaryKey,duplicateColumns)
+      }.getMessage
+
+      val tableColumns = deltaTable.toDF.columns.toSeq
+      val diff = duplicateColumns.diff(tableColumns)
+      assert(exceptionMessage.contains(s"these columns: $diff do not exists in the dataframe: $tableColumns"))
     }
   }
 }

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -1,0 +1,101 @@
+package mrpowers.jodie
+
+import com.github.mrpowers.spark.daria.sql.SparkSessionExt.SparkSessionMethods
+import com.github.mrpowers.spark.fast.tests.DataFrameComparer
+import io.delta.tables.DeltaTable
+import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.scalatest.{BeforeAndAfterEach, FunSpec}
+
+class DeltaHelperSpec extends FunSpec with SparkSessionTestWrapper with DataFrameComparer with BeforeAndAfterEach {
+
+  override def afterEach() {
+    val tmpDir = os.pwd / "tmp"
+    os.remove.all(tmpDir)
+  }
+
+  import spark.implicits._
+
+  describe("remove duplicate records from delta table"){
+    it("should remove duplicates successful"){
+      val path = (os.pwd / "tmp" / "delta-duplicate").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+        (5, "Jose", "Travolta"),
+        (6, "Jose", "Travolta"),
+        (7, "Maria", "Pitt")
+      ).toDF("id","firstname","lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq("firstname","lastname")
+      DeltaHelpers.removeDuplicateRecords(deltaTable,duplicateColumns)
+
+      val resultTable = spark.read.format("delta").load(path)
+      val expectedTable = Seq(
+        (2, "Maria", "Willis"),
+        (7, "Maria", "Pitt"),
+      ).toDF("id", "firstname", "lastname")
+
+      assertSmallDataFrameEquality(resultTable, expectedTable, orderedComparison = false, ignoreNullable = true)
+    }
+
+    it("should execute successful when applied into an empty table"){
+      val path = (os.pwd / "tmp" / "delta-duplicate-empty-table").toString()
+      val df = spark.createDF(List(),List(
+        ("id",IntegerType,true),
+        ("firstname",StringType,true),
+        ("lastname",StringType,true)),
+      )
+      df.write.format("delta").mode("overwrite").save(path)
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq("firstname","lastname")
+      DeltaHelpers.removeDuplicateRecords(deltaTable, duplicateColumns)
+      val resultTable = spark.read.format("delta").load(path)
+      val expectedTable = spark.createDF(List(), List(
+        ("id", IntegerType, true),
+        ("firstname", StringType, true),
+        ("lastname", StringType, true)),
+      )
+      assertSmallDataFrameEquality(resultTable,expectedTable,orderedComparison = false,ignoreNullable = true)
+    }
+
+    it("should fail to remove duplicate when duplicateColumns is empty"){
+      val path = (os.pwd / "tmp" / "delta-duplicate-empty-list").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq()
+      val e = intercept[NoSuchElementException]{
+        DeltaHelpers.removeDuplicateRecords(deltaTable, duplicateColumns)
+      }.getMessage
+
+      assert(e.contains("the input parameter duplicateColumns could not be empty"))
+    }
+
+    it("should fail to remove duplicate when duplicateColumns does not exist in table") {
+      val path = (os.pwd / "tmp" / "delta-duplicate-empty-list").toString()
+      val df = Seq(
+        (1, "Benito", "Jackson"),
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson"),
+      ).toDF("id", "firstname", "lastname")
+      df.write.format("delta").mode("overwrite").save(path)
+      val deltaTable = DeltaTable.forPath(path)
+      val duplicateColumns = Seq("firstname","name")
+      val e = intercept[JodieValidationError] {
+        DeltaHelpers.removeDuplicateRecords(deltaTable, duplicateColumns)
+      }.getMessage
+
+      assert(e.contains(s"there are columns in duplicateColumns:$duplicateColumns that do not exists in the deltaTable: ${deltaTable.toDF.columns.toSeq}"))
+    }
+  }
+}

--- a/src/test/scala/mrpowers/jodie/SparkSessionTestWrapper.scala
+++ b/src/test/scala/mrpowers/jodie/SparkSessionTestWrapper.scala
@@ -7,7 +7,14 @@ trait SparkSessionTestWrapper {
 
   lazy val spark: SparkSession = {
     Logger.getLogger("org").setLevel(Level.OFF)
-    SparkSession.builder().master("local").appName("spark session").getOrCreate()
+    SparkSession.builder()
+      .master("local")
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+      .config("spark.sql.warehouse.dir", (os.pwd / "tmp").toString())
+      .appName("spark session")
+      .getOrCreate()
   }
+  spark.sparkContext.setLogLevel(Level.OFF.toString)
 
 }


### PR DESCRIPTION
This implementation required updating the delta lake version to 2.1.0 and the spark version to 3.3.1 in order to be able to use the detail function of the delta lake class and obtain the properties and partition columns of the table. 
Reference link of the api: https://docs.delta.io/latest/api/scala/io/delta/tables/DeltaTable.html#detail():org.apache.spark.sql.DataFrame

This PR Solve the issue: https://github.com/MrPowers/jodie/issues/6

This PR must be merged after this other: https://github.com/MrPowers/jodie/pull/3