### PR TITLE
operation metric helper methods

### DIFF
--- a/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
+++ b/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
@@ -1,69 +1,13 @@
 package mrpowers.jodie
 
+import mrpowers.jodie.delta.{DeleteMetric, MergeMetric, OperationMetrics, WriteMetric}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.{DeltaHistory, DeltaLog}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{LongType, MapType, StringType, StructType}
 import org.apache.spark.sql.{DataFrame, Encoders, SparkSession}
-trait OperationMetrics
 
-case class DeleteMetric(
-    numDeletedRows: Long,
-    numAddedFiles: Long,
-    numCopiedRows: Long,
-    numRemovedFiles: Long,
-    numAddedChangeFiles: Long,
-    numRemovedBytes: Long,
-    numAddedBytes: Long,
-    executionTimeMs: Long,
-    scanTimeMs: Long,
-    rewriteTimeMs: Long
-) extends OperationMetrics
-case class RestoreMetric(
-    numRestoredFiles: Long,
-    removedFilesSize: Long,
-    numRemovedFiles: Long,
-    restoredFilesSize: Long,
-    numOfFilesAfterRestore: Long,
-    tableSizeAfterRestore: Long
-) extends OperationMetrics
-
-case class TBLProperties(enableCDF: Option[Boolean]) extends OperationMetrics
-
-case class WriteMetric(numFiles: Long, numOutputRows: Long, numOutputBytes: Long)
-    extends OperationMetrics
-
-case class VacuumMetric(numFilesToDelete: Long, sizeOfDataToDelete: Long) extends OperationMetrics
-
-case class CompactionMetric(
-    numRemovedFiles: Long,
-    numRemovedBytes: Long,
-    p25FileSize: Long,
-    minFileSize: Long,
-    numAddedFiles: Long,
-    maxFileSize: Long,
-    p75FileSize: Long,
-    p50FileSize: Long,
-    numAddedBytes: Long
-) extends OperationMetrics
-
-case class ZOrderByMetric(predicate: Seq[String], columns: Seq[String])
-
-case class MergeMetric(
-    numTargetRowsCopied: Long,
-    numTargetRowsDeleted: Long,
-    numTargetFilesAdded: Long,
-    executionTimeMs: Long,
-    numTargetRowsInserted: Long,
-    scanTimeMs: Long,
-    numTargetRowsUpdated: Long,
-    numOutputRows: Long,
-    numTargetChangeFilesAdded: Long,
-    numSourceRows: Long,
-    numTargetFilesRemoved: Long,
-    rewriteTimeMs: Long
-) extends OperationMetrics
 case class OperationMetricHelper(
     path: String,
     startingVersion: Long = 0,
@@ -103,7 +47,6 @@ case class OperationMetricHelper(
       version: Long
   ): Long = {
     import spark.implicits._
-    val deltaLog = DeltaLog.forTable(spark, path)
     val trimmed  = partitionCondition.trim
     val splitCondition =
       if (trimmed.contains(" and "))

--- a/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
+++ b/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
@@ -69,12 +69,113 @@ case class OperationMetricHelper(
     startingVersion: Long = 0,
     endingVersion: Option[Long] = None
 ) {
-  val spark    = SparkSession.active
-  val deltaLog = DeltaLog.forTable(spark, path)
-  def getOperationMetrics: Seq[(Long, OperationMetrics)] =
-    generateMetric(deltaLog.history.getHistory(startingVersion, endingVersion))
+  val spark                 = SparkSession.active
+  val deltaLog              = DeltaLog.forTable(spark, path)
+  private val metricColumns = Seq("version", "deleted", "inserted", "updated", "source_rows")
 
-  def generateMetric(
+  def getMetricsAsDF(): DataFrame = {
+    import spark.implicits._
+    getTransactionMetrics.toDF(metricColumns: _*)
+  }
+
+  def getMetricsAsDF(partitionCondition: String): DataFrame = {
+    import spark.implicits._
+    getTransactionMetrics(partitionCondition).toDF(metricColumns: _*)
+  }
+
+  def getTransactionMetrics: Seq[(Long, Long, Long, Long, Long)] = transformMetric(
+    generateMetric(deltaLog.history.getHistory(startingVersion, endingVersion))
+  )
+
+  def getTransactionMetrics(
+      partitionCondition: String
+  ): Seq[(Long, Long, Long, Long, Long)] = transformMetric(
+    generateMetric(
+      deltaLog.history
+        .getHistory(startingVersion, endingVersion)
+        .filter(x => filterHistoryByPartition(x, partitionCondition)),
+      Some(partitionCondition)
+    )
+  )
+
+  def getWriteMetricByPartition(
+      partitionCondition: String,
+      version: Long
+  ): Long = {
+    import spark.implicits._
+    val deltaLog = DeltaLog.forTable(spark, path)
+    val trimmed  = partitionCondition.trim
+    val splitCondition =
+      if (trimmed.contains(" and "))
+        trimmed.split(" and ").toSeq
+      else Seq(trimmed)
+    val conditions = splitCondition.map(x => {
+      val kv = x.split("=")
+      assert(kv.size == 2)
+      s"${kv.head.trim}=${kv.tail.head.trim.stripPrefix("\'").stripSuffix("\'")}"
+    })
+    val jsonSchema = new StructType()
+      .add("numRecords", LongType)
+      .add("minValues", MapType(StringType, StringType))
+      .add("maxValues", MapType(StringType, StringType))
+      .add("nullCount", MapType(StringType, StringType))
+    spark.read
+      .json(FileNames.deltaFile(deltaLog.logPath, version).toString)
+      .withColumn("stats", org.apache.spark.sql.functions.from_json(col("add.stats"), jsonSchema))
+      .select("add.path", "stats")
+      .map(x => {
+        val path = x.getAs[String]("path")
+        conditions.map(x => path != null && path.contains(x)).reduceOption(_ && _) match {
+          case None => 0L
+          case Some(bool) =>
+            if (bool)
+              x.getAs[String]("stats").asInstanceOf[GenericRowWithSchema].getAs[Long]("numRecords")
+            else 0L
+        }
+      })(Encoders.scalaLong)
+      .reduce(_ + _)
+  }
+
+  def transformMetric(
+      metric: Seq[(Long, OperationMetrics)]
+  ): Seq[(Long, Long, Long, Long, Long)] = metric
+    .filter(x =>
+      x._2.isInstanceOf[MergeMetric] || x._2.isInstanceOf[WriteMetric] || x._2
+        .isInstanceOf[DeleteMetric]
+    )
+    .map(x => {
+      val (deleted, inserted, updated, sourceRows) = x._2 match {
+        case MergeMetric(a, b, c, d, e, f, g, h, i, j, k, l) => (b, e, g, j)
+        case WriteMetric(a, b, c)                            => (0L, b, 0L, b)
+        case DeleteMetric(a, b, c, d, e, f, g, h, i, j)      => (a, 0L, 0L, 0L)
+        case _ =>
+          throw new IllegalArgumentException("Other Metric Types are not allowed in this method")
+      }
+      Tuple5.apply(x._1, deleted, inserted, updated, sourceRows)
+    })
+
+  private def filterHistoryByPartition(x: DeltaHistory, partitionCondition: String): Boolean =
+    x.operation match {
+      case "WRITE" => true
+      case "DELETE" | "MERGE" =>
+        if (
+          x.operationParameters
+            .contains("predicate") && x.operationParameters.get("predicate") != None
+        ) {
+          if (partitionCondition.trim.toLowerCase().contains(" and ")) {
+            val conditions = partitionCondition.split(" and ")
+            conditions.map(y => evaluateCondition(x, y)).reduce(_ && _)
+          } else evaluateCondition(x, partitionCondition)
+        } else {
+          false
+        }
+      case _ => false
+    }
+
+  private def evaluateCondition(x: DeltaHistory, partitionCondition: String) = {
+    x.operationParameters.get("predicate").get.contains(partitionCondition.trim)
+  }
+  private def generateMetric(
       deltaHistories: Seq[DeltaHistory],
       partitionCondition: Option[String] = None
   ): Seq[(Long, OperationMetrics)] =
@@ -130,117 +231,6 @@ case class OperationMetricHelper(
       })
       .filter(x => x._2 != null)
 
-  def whenContains(map: Map[String, String], key: String) =
+  private def whenContains(map: Map[String, String], key: String) =
     if (map.contains(key)) map(key).toLong else 0L
-  def extractCountMetric(op: OperationMetrics): (Long, Long, Long, Long) = op match {
-    case MergeMetric(a, b, c, d, e, f, g, h, i, j, k, l) => (b, e, g, j)
-    case WriteMetric(a, b, c)                            => (0L, b, 0L, b)
-    case DeleteMetric(a, b, c, d, e, f, g, h, i, j)      => (a, 0L, 0L, 0L)
-    case _ =>
-      throw new IllegalArgumentException("Other Metric Types are not allowed in this method")
-  }
-
-  def getTransactionMetrics: Seq[(Long, Long, Long, Long, Long)] =
-    getTransactionMetrics(getOperationMetrics)
-
-  def getMetricsAsDF(): DataFrame = {
-    import spark.implicits._
-    getTransactionMetrics.toDF("version", "deleted", "inserted", "updated", "source_rows")
-  }
-
-  def getMetricsAsDF(partitionCondition: String): DataFrame = {
-    import spark.implicits._
-    getMetricsByPartition(partitionCondition).toDF(
-      "version",
-      "deleted",
-      "inserted",
-      "updated",
-      "source_rows"
-    )
-  }
-
-  def getMetricsByPartition(
-      partitionCondition: String
-  ): Seq[(Long, Long, Long, Long, Long)] = {
-    val deltaHistories = deltaLog.history.getHistory(startingVersion, endingVersion)
-    getTransactionMetrics(
-      generateMetric(
-        deltaHistories
-          .filter(x => filterHistoryByPartition(x, partitionCondition)),
-        Some(partitionCondition)
-      )
-    )
-  }
-
-  def filterHistoryByPartition(x: DeltaHistory, partitionCondition: String): Boolean =
-    x.operation match {
-      case "WRITE" => true
-      case "DELETE" | "MERGE" =>
-        if (
-          x.operationParameters
-            .contains("predicate") && x.operationParameters.get("predicate") != None
-        ) {
-          if (partitionCondition.trim.toLowerCase().contains(" and ")) {
-            val conditions = partitionCondition.split(" and ")
-            conditions.map(y => evaluateCondition(x, y)).reduce(_ && _)
-          } else evaluateCondition(x, partitionCondition)
-        } else {
-          false
-        }
-      case _ => false
-    }
-
-  private def evaluateCondition(x: DeltaHistory, partitionCondition: String) = {
-    x.operationParameters.get("predicate").get.contains(partitionCondition.trim)
-  }
-
-  def getWriteMetricByPartition(
-      partitionCondition: String,
-      version: Long
-  ): Long = {
-    import spark.implicits._
-    val deltaLog = DeltaLog.forTable(spark, path)
-    val trimmed  = partitionCondition.trim
-    val splitCondition =
-      if (trimmed.contains(" and "))
-        trimmed.split(" and ").toSeq
-      else Seq(trimmed)
-    val conditions = splitCondition.map(x => {
-      val kv = x.split("=")
-      assert(kv.size == 2)
-      s"${kv.head.trim}=${kv.tail.head.trim.stripPrefix("\'").stripSuffix("\'")}"
-    })
-    val jsonSchema = new StructType()
-      .add("numRecords", LongType)
-      .add("minValues", MapType(StringType, StringType))
-      .add("maxValues", MapType(StringType, StringType))
-      .add("nullCount", MapType(StringType, StringType))
-    spark.read
-      .json(FileNames.deltaFile(deltaLog.logPath, version).toString)
-      .withColumn("stats", org.apache.spark.sql.functions.from_json(col("add.stats"), jsonSchema))
-      .select("add.path", "stats")
-      .map(x => {
-        val path = x.getAs[String]("path")
-        conditions.map(x => path != null && path.contains(x)).reduceOption(_ && _) match {
-          case None => 0L
-          case Some(bool) =>
-            if (bool)
-              x.getAs[String]("stats").asInstanceOf[GenericRowWithSchema].getAs[Long]("numRecords")
-            else 0L
-        }
-      })(Encoders.scalaLong)
-      .reduce(_ + _)
-  }
-
-  def getTransactionMetrics(
-      metric: Seq[(Long, OperationMetrics)]
-  ): Seq[(Long, Long, Long, Long, Long)] = metric
-    .filter(x =>
-      x._2.isInstanceOf[MergeMetric] || x._2.isInstanceOf[WriteMetric] || x._2
-        .isInstanceOf[DeleteMetric]
-    )
-    .map(x => {
-      val countMetric = extractCountMetric(x._2)
-      Tuple5.apply(x._1, countMetric._1, countMetric._2, countMetric._3, countMetric._4)
-    })
 }

--- a/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
+++ b/src/main/scala/mrpowers/jodie/OperationMetricHelper.scala
@@ -1,0 +1,246 @@
+package mrpowers.jodie
+
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.{DeltaHistory, DeltaLog}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{LongType, MapType, StringType, StructType}
+import org.apache.spark.sql.{DataFrame, Encoders, SparkSession}
+trait OperationMetrics
+
+case class DeleteMetric(
+    numDeletedRows: Long,
+    numAddedFiles: Long,
+    numCopiedRows: Long,
+    numRemovedFiles: Long,
+    numAddedChangeFiles: Long,
+    numRemovedBytes: Long,
+    numAddedBytes: Long,
+    executionTimeMs: Long,
+    scanTimeMs: Long,
+    rewriteTimeMs: Long
+) extends OperationMetrics
+case class RestoreMetric(
+    numRestoredFiles: Long,
+    removedFilesSize: Long,
+    numRemovedFiles: Long,
+    restoredFilesSize: Long,
+    numOfFilesAfterRestore: Long,
+    tableSizeAfterRestore: Long
+) extends OperationMetrics
+
+case class TBLProperties(enableCDF: Option[Boolean]) extends OperationMetrics
+
+case class WriteMetric(numFiles: Long, numOutputRows: Long, numOutputBytes: Long)
+    extends OperationMetrics
+
+case class VacuumMetric(numFilesToDelete: Long, sizeOfDataToDelete: Long) extends OperationMetrics
+
+case class CompactionMetric(
+    numRemovedFiles: Long,
+    numRemovedBytes: Long,
+    p25FileSize: Long,
+    minFileSize: Long,
+    numAddedFiles: Long,
+    maxFileSize: Long,
+    p75FileSize: Long,
+    p50FileSize: Long,
+    numAddedBytes: Long
+) extends OperationMetrics
+
+case class ZOrderByMetric(predicate: Seq[String], columns: Seq[String])
+
+case class MergeMetric(
+    numTargetRowsCopied: Long,
+    numTargetRowsDeleted: Long,
+    numTargetFilesAdded: Long,
+    executionTimeMs: Long,
+    numTargetRowsInserted: Long,
+    scanTimeMs: Long,
+    numTargetRowsUpdated: Long,
+    numOutputRows: Long,
+    numTargetChangeFilesAdded: Long,
+    numSourceRows: Long,
+    numTargetFilesRemoved: Long,
+    rewriteTimeMs: Long
+) extends OperationMetrics
+case class OperationMetricHelper(
+    path: String,
+    startingVersion: Long = 0,
+    endingVersion: Option[Long] = None
+) {
+  val spark    = SparkSession.active
+  val deltaLog = DeltaLog.forTable(spark, path)
+  def getOperationMetrics: Seq[(Long, OperationMetrics)] =
+    generateMetric(deltaLog.history.getHistory(startingVersion, endingVersion))
+
+  def generateMetric(
+      deltaHistories: Seq[DeltaHistory],
+      partitionCondition: Option[String] = None
+  ): Seq[(Long, OperationMetrics)] =
+    deltaHistories
+      .map(dh => {
+        (
+          dh.version.get, {
+            val metrics = dh.operationMetrics.get
+            dh.operation match {
+              case "MERGE" =>
+                MergeMetric(
+                  numTargetRowsCopied = metrics("numTargetRowsCopied").toLong,
+                  numTargetRowsDeleted = metrics("numTargetRowsDeleted").toLong,
+                  numTargetFilesAdded = metrics("numTargetFilesAdded").toLong,
+                  executionTimeMs = metrics("executionTimeMs").toLong,
+                  numTargetRowsInserted = metrics("numTargetRowsInserted").toLong,
+                  scanTimeMs = metrics("scanTimeMs").toLong,
+                  numTargetRowsUpdated = metrics("numTargetRowsUpdated").toLong,
+                  numOutputRows = metrics("numOutputRows").toLong,
+                  numTargetChangeFilesAdded = metrics("numTargetChangeFilesAdded").toLong,
+                  numSourceRows = metrics("numSourceRows").toLong,
+                  numTargetFilesRemoved = metrics("numTargetFilesRemoved").toLong,
+                  rewriteTimeMs = metrics("rewriteTimeMs").toLong
+                )
+              case "WRITE" =>
+                partitionCondition match {
+                  case None =>
+                    WriteMetric(
+                      numFiles = metrics("numFiles").toLong,
+                      numOutputRows = metrics("numOutputRows").toLong,
+                      numOutputBytes = metrics("numOutputBytes").toLong
+                    )
+                  case Some(condition) =>
+                    WriteMetric(0L, getWriteMetricByPartition(condition, dh.version.get), 0L)
+                }
+              case "DELETE" =>
+                DeleteMetric(
+                  numDeletedRows = whenContains(metrics, "numDeletedRows"),
+                  numAddedFiles = whenContains(metrics, "numAddedFiles"),
+                  numCopiedRows = whenContains(metrics, "numCopiedRows"),
+                  numRemovedFiles = whenContains(metrics, "numRemovedFiles"),
+                  numAddedChangeFiles = whenContains(metrics, "numAddedChangeFiles"),
+                  numRemovedBytes = whenContains(metrics, "numRemovedBytes"),
+                  numAddedBytes = whenContains(metrics, "numAddedBytes"),
+                  executionTimeMs = whenContains(metrics, "executionTimeMs"),
+                  scanTimeMs = whenContains(metrics, "scanTimeMs"),
+                  rewriteTimeMs = whenContains(metrics, "rewriteTimeMs")
+                )
+              case _ => null
+            }
+          }
+        )
+      })
+      .filter(x => x._2 != null)
+
+  def whenContains(map: Map[String, String], key: String) =
+    if (map.contains(key)) map(key).toLong else 0L
+  def extractCountMetric(op: OperationMetrics): (Long, Long, Long, Long) = op match {
+    case MergeMetric(a, b, c, d, e, f, g, h, i, j, k, l) => (b, e, g, j)
+    case WriteMetric(a, b, c)                            => (0L, b, 0L, b)
+    case DeleteMetric(a, b, c, d, e, f, g, h, i, j)      => (a, 0L, 0L, 0L)
+    case _ =>
+      throw new IllegalArgumentException("Other Metric Types are not allowed in this method")
+  }
+
+  def getTransactionMetrics: Seq[(Long, Long, Long, Long, Long)] =
+    getTransactionMetrics(getOperationMetrics)
+
+  def getMetricsAsDF(): DataFrame = {
+    import spark.implicits._
+    getTransactionMetrics.toDF("version", "deleted", "inserted", "updated", "source_rows")
+  }
+
+  def getMetricsAsDF(partitionCondition: String): DataFrame = {
+    import spark.implicits._
+    getMetricsByPartition(partitionCondition).toDF(
+      "version",
+      "deleted",
+      "inserted",
+      "updated",
+      "source_rows"
+    )
+  }
+
+  def getMetricsByPartition(
+      partitionCondition: String
+  ): Seq[(Long, Long, Long, Long, Long)] = {
+    val deltaHistories = deltaLog.history.getHistory(startingVersion, endingVersion)
+    getTransactionMetrics(
+      generateMetric(
+        deltaHistories
+          .filter(x => filterHistoryByPartition(x, partitionCondition)),
+        Some(partitionCondition)
+      )
+    )
+  }
+
+  def filterHistoryByPartition(x: DeltaHistory, partitionCondition: String): Boolean =
+    x.operation match {
+      case "WRITE" => true
+      case "DELETE" | "MERGE" =>
+        if (
+          x.operationParameters
+            .contains("predicate") && x.operationParameters.get("predicate") != None
+        ) {
+          if (partitionCondition.trim.toLowerCase().contains(" and ")) {
+            val conditions = partitionCondition.split(" and ")
+            conditions.map(y => evaluateCondition(x, y)).reduce(_ && _)
+          } else evaluateCondition(x, partitionCondition)
+        } else {
+          false
+        }
+      case _ => false
+    }
+
+  private def evaluateCondition(x: DeltaHistory, partitionCondition: String) = {
+    x.operationParameters.get("predicate").get.contains(partitionCondition.trim)
+  }
+
+  def getWriteMetricByPartition(
+      partitionCondition: String,
+      version: Long
+  ): Long = {
+    import spark.implicits._
+    val deltaLog = DeltaLog.forTable(spark, path)
+    val trimmed  = partitionCondition.trim
+    val splitCondition =
+      if (trimmed.contains(" and "))
+        trimmed.split(" and ").toSeq
+      else Seq(trimmed)
+    val conditions = splitCondition.map(x => {
+      val kv = x.split("=")
+      assert(kv.size == 2)
+      s"${kv.head.trim}=${kv.tail.head.trim.stripPrefix("\'").stripSuffix("\'")}"
+    })
+    val jsonSchema = new StructType()
+      .add("numRecords", LongType)
+      .add("minValues", MapType(StringType, StringType))
+      .add("maxValues", MapType(StringType, StringType))
+      .add("nullCount", MapType(StringType, StringType))
+    spark.read
+      .json(FileNames.deltaFile(deltaLog.logPath, version).toString)
+      .withColumn("stats", org.apache.spark.sql.functions.from_json(col("add.stats"), jsonSchema))
+      .select("add.path", "stats")
+      .map(x => {
+        val path = x.getAs[String]("path")
+        conditions.map(x => path != null && path.contains(x)).reduceOption(_ && _) match {
+          case None => 0L
+          case Some(bool) =>
+            if (bool)
+              x.getAs[String]("stats").asInstanceOf[GenericRowWithSchema].getAs[Long]("numRecords")
+            else 0L
+        }
+      })(Encoders.scalaLong)
+      .reduce(_ + _)
+  }
+
+  def getTransactionMetrics(
+      metric: Seq[(Long, OperationMetrics)]
+  ): Seq[(Long, Long, Long, Long, Long)] = metric
+    .filter(x =>
+      x._2.isInstanceOf[MergeMetric] || x._2.isInstanceOf[WriteMetric] || x._2
+        .isInstanceOf[DeleteMetric]
+    )
+    .map(x => {
+      val countMetric = extractCountMetric(x._2)
+      Tuple5.apply(x._1, countMetric._1, countMetric._2, countMetric._3, countMetric._4)
+    })
+}

--- a/src/main/scala/mrpowers/jodie/delta/OperationMetric.scala
+++ b/src/main/scala/mrpowers/jodie/delta/OperationMetric.scala
@@ -1,0 +1,60 @@
+package mrpowers.jodie.delta
+
+sealed trait OperationMetrics
+
+case class DeleteMetric(
+                         numDeletedRows: Long,
+                         numAddedFiles: Long,
+                         numCopiedRows: Long,
+                         numRemovedFiles: Long,
+                         numAddedChangeFiles: Long,
+                         numRemovedBytes: Long,
+                         numAddedBytes: Long,
+                         executionTimeMs: Long,
+                         scanTimeMs: Long,
+                         rewriteTimeMs: Long
+                       ) extends OperationMetrics
+case class RestoreMetric(
+                          numRestoredFiles: Long,
+                          removedFilesSize: Long,
+                          numRemovedFiles: Long,
+                          restoredFilesSize: Long,
+                          numOfFilesAfterRestore: Long,
+                          tableSizeAfterRestore: Long
+                        ) extends OperationMetrics
+
+case class TBLProperties(enableCDF: Option[Boolean]) extends OperationMetrics
+
+case class WriteMetric(numFiles: Long, numOutputRows: Long, numOutputBytes: Long)
+  extends OperationMetrics
+
+case class VacuumMetric(numFilesToDelete: Long, sizeOfDataToDelete: Long) extends OperationMetrics
+
+case class CompactionMetric(
+                             numRemovedFiles: Long,
+                             numRemovedBytes: Long,
+                             p25FileSize: Long,
+                             minFileSize: Long,
+                             numAddedFiles: Long,
+                             maxFileSize: Long,
+                             p75FileSize: Long,
+                             p50FileSize: Long,
+                             numAddedBytes: Long
+                           ) extends OperationMetrics
+
+case class ZOrderByMetric(predicate: Seq[String], columns: Seq[String])
+
+case class MergeMetric(
+                        numTargetRowsCopied: Long,
+                        numTargetRowsDeleted: Long,
+                        numTargetFilesAdded: Long,
+                        executionTimeMs: Long,
+                        numTargetRowsInserted: Long,
+                        scanTimeMs: Long,
+                        numTargetRowsUpdated: Long,
+                        numOutputRows: Long,
+                        numTargetChangeFilesAdded: Long,
+                        numSourceRows: Long,
+                        numTargetFilesRemoved: Long,
+                        rewriteTimeMs: Long
+                      ) extends OperationMetrics

--- a/src/main/scala/mrpowers/jodie/delta/OperationMetric.scala
+++ b/src/main/scala/mrpowers/jodie/delta/OperationMetric.scala
@@ -1,60 +1,43 @@
 package mrpowers.jodie.delta
 
 sealed trait OperationMetrics
-
 case class DeleteMetric(
-                         numDeletedRows: Long,
-                         numAddedFiles: Long,
-                         numCopiedRows: Long,
-                         numRemovedFiles: Long,
-                         numAddedChangeFiles: Long,
-                         numRemovedBytes: Long,
-                         numAddedBytes: Long,
-                         executionTimeMs: Long,
-                         scanTimeMs: Long,
-                         rewriteTimeMs: Long
-                       ) extends OperationMetrics
-case class RestoreMetric(
-                          numRestoredFiles: Long,
-                          removedFilesSize: Long,
-                          numRemovedFiles: Long,
-                          restoredFilesSize: Long,
-                          numOfFilesAfterRestore: Long,
-                          tableSizeAfterRestore: Long
-                        ) extends OperationMetrics
+    numDeletedRows: Long,
+    numAddedFiles: Long,
+    numCopiedRows: Long,
+    numRemovedFiles: Long,
+    numAddedChangeFiles: Long,
+    numRemovedBytes: Long,
+    numAddedBytes: Long,
+    executionTimeMs: Long,
+    scanTimeMs: Long,
+    rewriteTimeMs: Long
+) extends OperationMetrics
 
-case class TBLProperties(enableCDF: Option[Boolean]) extends OperationMetrics
-
+case class UpdateMetric(
+    numRemovedFiles: Long,
+    numCopiedRows: Long,
+    numAddedChangeFiles: Long,
+    executionTimeMs: Long,
+    scanTimeMs: Long,
+    numAddedFiles: Long,
+    numUpdatedRows: Long,
+    rewriteTimeMs: Long
+) extends OperationMetrics
 case class WriteMetric(numFiles: Long, numOutputRows: Long, numOutputBytes: Long)
-  extends OperationMetrics
-
-case class VacuumMetric(numFilesToDelete: Long, sizeOfDataToDelete: Long) extends OperationMetrics
-
-case class CompactionMetric(
-                             numRemovedFiles: Long,
-                             numRemovedBytes: Long,
-                             p25FileSize: Long,
-                             minFileSize: Long,
-                             numAddedFiles: Long,
-                             maxFileSize: Long,
-                             p75FileSize: Long,
-                             p50FileSize: Long,
-                             numAddedBytes: Long
-                           ) extends OperationMetrics
-
-case class ZOrderByMetric(predicate: Seq[String], columns: Seq[String])
+    extends OperationMetrics
 
 case class MergeMetric(
-                        numTargetRowsCopied: Long,
-                        numTargetRowsDeleted: Long,
-                        numTargetFilesAdded: Long,
-                        executionTimeMs: Long,
-                        numTargetRowsInserted: Long,
-                        scanTimeMs: Long,
-                        numTargetRowsUpdated: Long,
-                        numOutputRows: Long,
-                        numTargetChangeFilesAdded: Long,
-                        numSourceRows: Long,
-                        numTargetFilesRemoved: Long,
-                        rewriteTimeMs: Long
-                      ) extends OperationMetrics
+    numTargetRowsCopied: Long,
+    numTargetRowsDeleted: Long,
+    numTargetFilesAdded: Long,
+    executionTimeMs: Long,
+    numTargetRowsInserted: Long,
+    scanTimeMs: Long,
+    numTargetRowsUpdated: Long,
+    numOutputRows: Long,
+    numTargetChangeFilesAdded: Long,
+    numSourceRows: Long,
+    numTargetFilesRemoved: Long,
+    rewriteTimeMs: Long
+) extends OperationMetrics

--- a/src/test/scala/mrpowers/jodie/ChangeDataFeedHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/ChangeDataFeedHelperSpec.scala
@@ -2,6 +2,7 @@ package mrpowers.jodie
 
 import com.github.mrpowers.spark.fast.tests.DataFrameComparer
 import io.delta.tables.DeltaTable
+import mrpowers.jodie.DeltaTestUtils.executeMergeFor
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.delta.util.FileNames
@@ -245,18 +246,5 @@ class ChangeDataFeedHelperSpec extends AnyFunSpec
     table
   }
 
-  def executeMergeFor(tableName: String, deltaTable: DeltaTable, updates: List[(Int, String, Int)]) = {
-    import spark.implicits._
-    updates.foreach(row => {
-      val dataFrame = Seq(row).toDF("id", "gender", "age")
-      deltaTable.as(tableName)
-        .merge(dataFrame.as("source"), s"${tableName}.id = source.id")
-        .whenMatched
-        .updateAll()
-        .whenNotMatched()
-        .insertAll()
-        .execute()
-    })
-    deltaTable
-  }
+
 }

--- a/src/test/scala/mrpowers/jodie/DeltaTestUtils.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaTestUtils.scala
@@ -1,0 +1,35 @@
+package mrpowers.jodie
+
+import io.delta.tables.DeltaTable
+
+object DeltaTestUtils extends SparkSessionTestWrapper{
+  def executeMergeFor(tableName: String, deltaTable: DeltaTable, updates: List[(Int, String, Int)]) = {
+    import spark.implicits._
+    updates.foreach(row => {
+      val dataFrame = Seq(row).toDF("id", "gender", "age")
+      deltaTable.as(tableName)
+        .merge(dataFrame.as("source"), s"${tableName}.id = source.id")
+        .whenMatched
+        .updateAll()
+        .whenNotMatched()
+        .insertAll()
+        .execute()
+    })
+    deltaTable
+  }
+
+  def executeMergeWithReducedSearchSpace(tableName: String, deltaTable: DeltaTable, updates: List[(Int, String, Int,String)], condition:String)={
+    import spark.implicits._
+    updates.foreach(row => {
+      val dataFrame = Seq(row).toDF("id", "gender", "age","country")
+      deltaTable.as(tableName)
+        .merge(dataFrame.as("source"), s"${tableName}.id = source.id and $condition")
+        .whenMatched
+        .updateAll()
+        .whenNotMatched()
+        .insertAll()
+        .execute()
+    })
+    deltaTable
+  }
+}

--- a/src/test/scala/mrpowers/jodie/OperationMetricHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/OperationMetricHelperSpec.scala
@@ -1,0 +1,204 @@
+package mrpowers.jodie
+
+import com.github.mrpowers.spark.fast.tests.DataFrameComparer
+import io.delta.tables.DeltaTable
+import org.apache.spark.sql.DataFrame
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+
+class OperationMetricHelperSpec
+    extends AnyFunSpec
+    with SparkSessionTestWrapper
+    with DataFrameComparer
+    with BeforeAndAfterEach {
+  var writePath = ""
+  override def afterEach(): Unit = {
+    val tmpDir = os.pwd / "tmp" / "delta-opm"
+    os.remove.all(tmpDir)
+  }
+
+  describe("When Delta Table has relevant operation metric") {
+    val rows    = Seq((1, "Male", 25), (2, "Female", 35), (3, "Female", 45), (4, "Male", 18))
+    val updates = List((1, "Male", 35), (2, "Male", 100), (5, "Male", 101), (4, "Female", 18))
+    val path    = (os.pwd / "tmp" / "delta-opm").toString()
+    import spark.implicits._
+    val snapshotDF = rows.toDF("id", "gender", "age")
+    it("should return valid count metric") {
+      val name = "snapshot"
+      val deltaTable =
+        DeltaTestUtils.executeMergeFor(
+          name,
+          createDeltaTable(name, snapshotDF, path, None),
+          updates
+        )
+      deltaTable.delete("id == 5")
+      Seq((10, "Female", 35))
+        .toDF("id", "gender", "age")
+        .write
+        .format("delta")
+        .mode("append")
+        .save(writePath)
+      val actualDF = OperationMetricHelper(writePath).getMetricsAsDF()
+      val expected = toVersionDF(
+        Seq(
+          (6L, 0L, 1L, 0L, 1L),
+          (5L, 1L, 0L, 0L, 0L),
+          (4L, 0L, 0L, 1L, 1L),
+          (3L, 0L, 1L, 0L, 1L),
+          (2L, 0L, 0L, 1L, 1L),
+          (1L, 0L, 0L, 1L, 1L),
+          (0L, 0L, 4L, 0L, 4L)
+        )
+      )
+      assertSmallDataFrameEquality(actualDF, expected)
+    }
+    it("should return valid metric for single partition column") {
+      partitionWithMerge("partitioned_snapshot", rows, updates, path)
+      val actual = OperationMetricHelper(writePath).getMetricsAsDF(" country = 'USA'")
+      val expected =
+        toVersionDF(Seq((4L, 0L, 0L, 1L, 1L), (3L, 0L, 0L, 1L, 1L), (0L, 0L, 2L, 0L, 2L)))
+      assertSmallDataFrameEquality(actual, expected)
+    }
+    it("should return valid metric for single partition column containing deletes and appends") {
+      val deltaTable = partitionWithMerge("single_partitioned_snapshot", rows, updates, path)
+      deltaTable.delete("country == 'USA' and age == 100")
+      Seq((10, "Female", 35, "USA"))
+        .toDF("id", "gender", "age", "country")
+        .write
+        .format("delta")
+        .mode("append")
+        .partitionBy("country")
+        .save(writePath)
+      val condition = " country = 'USA'"
+      val actual    = OperationMetricHelper(writePath).getMetricsAsDF(" country = 'USA'")
+      val expected =
+        toVersionDF(
+          Seq(
+            (6L, 0L, 1L, 0, 1L),
+            (5L, 1L, 0L, 0L, 0L),
+            (4L, 0L, 0L, 1L, 1L),
+            (3L, 0L, 0L, 1L, 1L),
+            (0L, 0L, 2L, 0L, 2L)
+          )
+        )
+      assertSmallDataFrameEquality(actual, expected)
+    }
+    it("should return valid metric for multiple partition columns") {
+      val deltaTable = multiplePartitionWithMerge("multi_partitioned_snapshot", rows, updates, path)
+      deltaTable.delete("country == 'USA' and gender = 'Female' and id == 2")
+      Seq((10, "Female", 35, "USA"))
+        .toDF("id", "gender", "age", "country")
+        .write
+        .format("delta")
+        .mode("append")
+        .partitionBy("country", "gender")
+        .save(writePath)
+      val actual = OperationMetricHelper(writePath).getMetricsAsDF(
+        " country = 'USA' and gender = 'Female'"
+      )
+      val expected =
+        toVersionDF(
+          Seq(
+            (6L, 0L, 1L, 0L, 1L),
+            (5L, 1L, 0L, 0L, 0L),
+            (1L, 0L, 1L, 0L, 1L),
+            (0L, 0L, 1L, 0L, 1L)
+          )
+        )
+      assertSmallDataFrameEquality(actual, expected)
+    }
+  }
+
+  private def partitionWithMerge(
+      tableName: String,
+      rows: Seq[(Int, String, Int)],
+      updates: List[(Int, String, Int)],
+      path: String
+  ): DeltaTable = {
+    import spark.implicits._
+    val rowsWithCountry = rows.map(x => appendCountry(x))
+    val deltaTable = createDeltaTable(
+      tableName,
+      rowsWithCountry.toDF("id", "gender", "age", "country"),
+      path,
+      Some(Seq("country"))
+    )
+    val upsertCandidates = updates.map(x => appendCountry(x))
+    upsertCandidates
+      .groupBy(x => x._4)
+      .foreach(y => {
+        DeltaTestUtils.executeMergeWithReducedSearchSpace(
+          tableName,
+          deltaTable,
+          y._2,
+          s" ${tableName}.country == '${y._1}'"
+        )
+        ()
+      })
+    deltaTable
+  }
+
+  private def multiplePartitionWithMerge(
+      tableName: String,
+      rows: Seq[(Int, String, Int)],
+      updates: List[(Int, String, Int)],
+      path: String
+  ): DeltaTable = {
+    import spark.implicits._
+    val rowsWithCountry = rows.map(x => appendCountry(x))
+    val deltaTable = createDeltaTable(
+      tableName,
+      rowsWithCountry.toDF("id", "gender", "age", "country"),
+      path,
+      Some(Seq("country", "gender"))
+    )
+    val upsertCandidates = updates.map(x => appendCountry(x))
+    upsertCandidates
+      .groupBy(x => (x._4, x._2))
+      .foreach(y => {
+        DeltaTestUtils.executeMergeWithReducedSearchSpace(
+          tableName,
+          deltaTable,
+          y._2,
+          s" ${tableName}.country == '${y._1._1}' and ${tableName}.gender == '${y._1._2}'"
+        )
+        ()
+      })
+    deltaTable
+  }
+
+  private def toVersionDF(s: Seq[(Long, Long, Long, Long, Long)]): DataFrame = {
+    import spark.implicits._
+    s.toDF(
+      "version",
+      "deleted",
+      "inserted",
+      "updated",
+      "source_rows"
+    )
+  }
+
+  private def appendCountry(x: (Int, String, Int)) = {
+    if (x._1 % 2 == 0) (x._1, x._2, x._3, "USA") else (x._1, x._2, x._3, "IND")
+  }
+
+  def createDeltaTable(
+      tableName: String,
+      snapshotDF: DataFrame,
+      path: String,
+      partitionColumn: Option[Seq[String]]
+  ) = {
+    writePath = path + "/" + tableName
+    partitionColumn match {
+      case None => snapshotDF.write.format("delta").save(writePath)
+      case Some(pc) =>
+        snapshotDF.write
+          .format("delta")
+          .partitionBy(pc: _*)
+          .save(writePath)
+    }
+    spark.sql(s"CREATE TABLE default.${tableName} USING DELTA LOCATION  '${writePath}' ")
+    DeltaTable.forPath(writePath)
+  }
+
+}

--- a/src/test/scala/mrpowers/jodie/OperationMetricHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/OperationMetricHelperSpec.scala
@@ -96,12 +96,18 @@ class OperationMetricHelperSpec
       val actual = OperationMetricHelper(writePath).getMetricsAsDF(
         " country = 'USA' and gender = 'Female'"
       )
+      val versionDF = deltaTable
+        .history()
+        .filter(" version > 0 and version < 5")
+        .select("version", "operationParameters.predicate")
+        .filter("predicate like '%USA%' and predicate like '%Female%'")
+      assert(versionDF.count() == 1)
       val expected =
         toVersionDF(
           Seq(
             (6L, 0L, 1L, 0L, 1L),
             (5L, 1L, 0L, 0L, 0L),
-            (1L, 0L, 1L, 0L, 1L),
+            (versionDF.take(1).head.getAs[Long]("version"), 0L, 1L, 0L, 1L),
             (0L, 0L, 1L, 0L, 1L)
           )
         )


### PR DESCRIPTION
Created two specific helper methods which present the operation metrics in a human-readable format:-
```scala
+-------+-------+--------+-------+-----------+
|version|deleted|inserted|updated|source_rows|
+-------+-------+--------+-------+-----------+
|6      |0      |1       |0      |1          |
|5      |1      |0       |0      |0          |
|4      |0      |0       |1      |1          |
|3      |0      |1       |0      |1          |
|2      |0      |0       |1      |1          |
|1      |0      |0       |1      |1          |
|0      |0      |4       |0      |4          |
+-------+-------+--------+-------+-----------+
```

`OperationMetricHelper(path).getMetricAsDF` - Works on any Delta Table and presents the no.of rows inserted/updated/deleted per version in a delta table along with no. of input/source row (as shown above)

`OperationMetricHelper(path).getMetricAsDF(partitionCondition: String)` - This one is more interesting. It provides the above metrics but this time at a column partition level. This is related to a blog I am writing w.r.t. to concurrency control. I will update here once it's done.

@brayanjuls @MrPowers  This is still WIP but I wanted to put it as a draft PR so that you guys can take a look even before I finish and suggest changes