### PR TITLE
Implement composite key candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Now execute the function:
 ```scala
 val result = DeltaHelpers.isCompositeKeyCandidate(
   deltaTable = deltaTable,
-  excludeCols = Seq("id", "firstName")
+  cols = Seq("id", "firstName")
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,37 @@ The result will be the following:
 Seq("firstname","lastname")
 ```
 
+### Validate Composite Key
+The  `isCompositeKeyCandidate` function aids in verifying whether a given composite key qualifies as a unique key within your Delta table. 
+It returns true if the key is considered a potential composite key, and false otherwise.
+
+Suppose we have the following table:
+
+```
++----+---------+---------+
+|  id|firstname| lastname|
++----+---------+---------+
+|   1|   Benito|  Jackson|
+|   4|    Maria|     Pitt|
+|   6|  Rosalia| Travolta|
++----+---------+---------+
+```
+
+Now execute the function:
+```scala
+val result = DeltaHelpers.isCompositeKeyCandidate(
+  deltaTable = deltaTable,
+  excludeCols = Seq("id", "firstName")
+)
+```
+
+The result will be the following:
+
+```scala
+true
+```
+
+
 ## Delta File Sizes
 
 The `deltaFileSizes` function returns a `Map[String,Long]` that contains the total size in bytes, the amount of files and the

--- a/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
+++ b/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
@@ -469,9 +469,9 @@ object DeltaHelpers {
       throw new NoSuchElementException(s"The base table has these columns ${df.columns.mkString(",")}, but these columns are required ${cols.mkString(",")}")
 
     val duplicateRecords = deltaTable.toDF
-      .withColumn("amount_of_records", row_number().over(partitionedWindow))
-      .filter(col("amount_of_records") > 1)
-      .drop(col("amount_of_records"))
+      .groupBy(partitionColumn: _*).count()
+      .filter(col("count") > 1)
+      .drop(col("count"))
 
     duplicateRecords.isEmpty
   }

--- a/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
+++ b/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
@@ -479,7 +479,8 @@ object DeltaHelpers {
       throw new NoSuchElementException(s"The base table has these columns ${df.columns.mkString(",")}, but these columns are required ${cols.mkString(",")}")
 
     // Apply a function to check for duplicate records based on the specified keys.
-    val duplicateRecords = deltaTable.toDF
+    val duplicateRecords =
+      deltaTable.toDF
       .groupBy(partitionColumn: _*).count()
       .filter(col("count") > 1)
       .drop(col("count"))

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -1030,10 +1030,8 @@ class DeltaHelperSpec
         .save(path)
 
       val deltaTable = DeltaTable.forPath(path)
-      Try(DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols)) match {
-        case Failure(_) => fail("isCompositeKeyCandidate function should return an exception when the list of columns is empty")
-        case Success(result) => assert(result)
-      }
+
+      assert(DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols))
     }
 
 
@@ -1054,11 +1052,8 @@ class DeltaHelperSpec
         .save(path)
 
       val deltaTable = DeltaTable.forPath(path)
-      Try(DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols)) match {
-        case Failure(_) => fail("isCompositeKeyCandidate function should return an exception when the list of columns is empty")
-        case Success(result) => assert(!result)
-      }
+
+      assert(!DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols))
     }
   }
-
 }

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -1012,6 +1012,53 @@ class DeltaHelperSpec
         case Success(_) => fail("isCompositeKeyCandidate function should return an exception when the list of columns is empty")
       }
     }
+
+    it("Should return true when the compose key is a valid key") {
+      val path = (os.pwd / "tmp" / "delta-tbl").toString()
+      val df = Seq(
+        (2, "Maria", "Willis"),
+        (3, "Jose", "Travolta"),
+        (4, "Benito", "Jackson")
+      ).toDF("id", "firstname", "lastname")
+
+      val cols = List("id", "firstname")
+
+      df
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      Try(DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols)) match {
+        case Failure(_) => fail("isCompositeKeyCandidate function should return an exception when the list of columns is empty")
+        case Success(result) => assert(result)
+      }
+    }
+
+
+    it("Should return false when the compose key is an invalid key") {
+      val path = (os.pwd / "tmp" / "delta-tbl").toString()
+      val df = Seq(
+        (2, "Maria", "Willis"),
+        (3, "Benito", "Jackson"),
+        (4, "Benito", "Jackson")
+      ).toDF("id", "firstname", "lastname")
+
+      val cols = List("firstname", "lastname")
+
+      df
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(path)
+
+      val deltaTable = DeltaTable.forPath(path)
+      Try(DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols)) match {
+        case Failure(_) => fail("isCompositeKeyCandidate function should return an exception when the list of columns is empty")
+        case Success(result) => assert(!result)
+      }
+    }
   }
 
 }


### PR DESCRIPTION
The function isCompositeKeyCandidate is created to validate whether a set of columns in a Delta table is a candidate to be a composite key.

Issue: https://github.com/MrPowers/jodie/issues/39
