### PR TITLE
Multi cluster write detection

### DIFF
--- a/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
+++ b/src/main/scala/mrpowers/jodie/DeltaHelpers.scala
@@ -616,7 +616,7 @@ object DeltaHelpers {
             val escapedSearchString = condition.replace("=", "\\=")
             val regexPattern = s".*${escapedSearchString.replace(" ", "\\s*")}.*"
             val regex = regexPattern.r
-            regex.findFirstIn(op).isDefined
+            regex.findFirstIn(op.replaceAll("#\\d+", "")).isDefined
           }).reduce(_ && _)
       }).filter(x => x == true).size match {
         case 0 => (false, providedPartitions)

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -1192,6 +1192,7 @@ class DeltaHelperSpec
 
       assert(!DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols))
     }
+  }
 
     describe("When Multi Cluster Write happens for Delta Lake") {
       def mergeToObtainSuccessiveVersions(deltaTable: DeltaTable): Unit = {
@@ -1231,7 +1232,7 @@ class DeltaHelperSpec
       }
       it("Should return invalid sanity check on erroneous versions") {
         val path = (os.pwd / "tmp" / "delta-table-mcw-error").toString()
-        //mimicMultiClusterWrite(path, false)
+        mimicMultiClusterWrite(path, false)
         val actual = DeltaHelpers.checkLastMultiClusterWrite(path, 1, 4)
         actual._1 should equal(false)
         actual._2.head._1 should equal(0)
@@ -1267,5 +1268,4 @@ class DeltaHelperSpec
         actual._2.filter(x => x._1 == true).size should equal(4)
       }
     }
-  }
 }

--- a/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
+++ b/src/test/scala/mrpowers/jodie/DeltaHelperSpec.scala
@@ -1192,5 +1192,80 @@ class DeltaHelperSpec
 
       assert(!DeltaHelpers.isCompositeKeyCandidate(deltaTable, cols))
     }
+
+    describe("When Multi Cluster Write happens for Delta Lake") {
+      def mergeToObtainSuccessiveVersions(deltaTable: DeltaTable): Unit = {
+        import spark.implicits._
+        minMaxRows.groupBy(x => x._3).foreach(x => {
+          val updates = x._2.toDF("id", "firstname", "lastname")
+          deltaTable.as("snapshot").merge(updates.as("delta"),
+            s"snapshot.id = delta.id and snapshot.lastname = '${x._1}'")
+            .whenMatched().updateAll()
+            .execute()
+        })
+      }
+
+      def mimicMultiClusterWrite(path: String, modifyMetadata: Boolean): Unit = {
+        spark.conf.set("spark.sql.files.maxRecordsPerFile", "4")
+        createBaseDeltaTableWithPartitions(path, Seq("lastname"), minMaxRows)
+        val deltaTable = DeltaTable.forPath(path)
+        mergeToObtainSuccessiveVersions(deltaTable)
+        modifyMetadata match {
+          case true => spark.sql(s"ALTER TABLE delta.`${path}` SET TBLPROPERTIES (delta.enableChangeDataFeed = true)")
+            mergeToObtainSuccessiveVersions(deltaTable)
+          case false =>
+        }
+      }
+
+      it("Should return valid sanity check on existing versions") {
+        val path = (os.pwd / "tmp" / "delta-table-mcw-valid").toString()
+        mimicMultiClusterWrite(path, false)
+        val actual = DeltaHelpers.checkLastMultiClusterWrite(path, 0, 4)
+        actual._1 should equal(true)
+        actual._2.last._1 should equal(4)
+        var checkVersions = 0
+        actual._2.foreach(x => {
+          x._1 should equal(checkVersions)
+          checkVersions = checkVersions + 1
+        })
+      }
+      it("Should return invalid sanity check on erroneous versions") {
+        val path = (os.pwd / "tmp" / "delta-table-mcw-error").toString()
+        //mimicMultiClusterWrite(path, false)
+        val actual = DeltaHelpers.checkLastMultiClusterWrite(path, 1, 4)
+        actual._1 should equal(false)
+        actual._2.head._1 should equal(0)
+      }
+
+      it("Should return invalid on delta table alterations conflicting with MCW") {
+        val path = (os.pwd / "tmp" / "delta-table-mcw-conflict").toString()
+        mimicMultiClusterWrite(path, true)
+        val actual = DeltaHelpers.checkLastMultiClusterWrite(path, 4, 4)
+        actual._1 should equal(false)
+        actual._2.head._1 should equal(5)
+      }
+
+
+      it("Should return invalid sanity check with erroneous versions identified") {
+        val path = (os.pwd / "tmp" / "delta-table-mcw-error-identified").toString()
+        mimicMultiClusterWrite(path, true)
+        val actual = DeltaHelpers.checkMultiClusterWriteBetweenVersions(path,
+          List("lastname = 'Willis' and id = delta.id", "lastname = 'Travolta' and id = delta.id",
+            "lastname = 'Pitt' and id = delta.id", "lastname = 'Roy' and id = delta.id"), 0, Some(4))
+        actual._1 should equal(false)
+        actual._2.filter(x => x._1 == false).size should equal(1)
+        actual._2.filter(x => x._1 == true).size should equal(3)
+      }
+      it("Should return valid sanity check with correct versions matched") {
+        val path = (os.pwd / "tmp" / "delta-table-mcw-correct-match").toString()
+        mimicMultiClusterWrite(path, true)
+        val actual = DeltaHelpers.checkMultiClusterWriteBetweenVersions(path,
+          List("lastname = 'Willis' and id = delta.id", "lastname = 'Travolta' and id = delta.id",
+            "lastname = 'Pitt' and id = delta.id", "lastname = 'Jackson' and id = delta.id"), 0, Some(4))
+        actual._1 should equal(true)
+        actual._2.filter(x => x._1 == false).size should equal(0)
+        actual._2.filter(x => x._1 == true).size should equal(4)
+      }
+    }
   }
 }


### PR DESCRIPTION
We faced a production issue with some of our pipelines while using Delta 1.0.1 and as a follow-up, we raised an [issue](https://github.com/delta-io/delta/issues/2455) on Delta core. While it seems that this issue is not present with Delta 2.x, it became imperative for us to detect it whenever it occurs and be able to fix it right there as we faced production data loss. Moreover, with the advent of various cloud providers, it becomes even more essential to detect it because it is sometimes ambiguous whether they provide the [guarantees](https://docs.delta.io/latest/delta-storage.html#storage-configuration) or not like we faced in the case of GCP. More information can be found in this [blog](https://delta.io/blog/2022-05-18-multi-cluster-writes-to-delta-lake-storage-in-s3/) by Denny Lee.

In this PR, there are 2 methods that can help in easy detection as the logic turns out to be simple despite the complicated name. Please suggest other variations of this method if you deem fit @brayanjuls @MrPowers 